### PR TITLE
Fixed bug causing vector regridding to crash

### DIFF
--- a/MAPL_Base/MAPL_newCFIO.F90
+++ b/MAPL_Base/MAPL_newCFIO.F90
@@ -848,8 +848,8 @@ module MAPL_newCFIOMod
              this%read_collection_id, fileName, trim(names(i)), &
              & ref, start=localStart, global_start=globalStart, global_count=globalCount)
         deallocate(localStart,globalStart,globalCount)
-        deallocate(gridLocalStart,gridGlobalStart,gridGlobalCount)
      enddo
+     deallocate(gridLocalStart,gridGlobalStart,gridGlobalCount)
      this%input_bundle = ESMF_FieldBundleCreate(fieldList=input_fields,rc=status)
      _VERIFY(status)
      _RETURN(_SUCCESS)


### PR DESCRIPTION
In MAPL_newCFIO/process_data_from_files, three variables were being deallocated inside a loop when they should have been deallocated outside the loop. This only causes problems when reading more than one field at a time, which only happens in GCHP when reading in vector data. This should be fixed by moving that deallocate line outside the loop.

## Description
Fix for a bug in MAPL which causes GCHP to crash when attempting vector regridding.

## Related Issue
Issues appear to be disabled for this repo.

## Motivation and Context
Re-enables vector regridding (with removal of logical check in ExtDataGridCompMod).

## How Has This Been Tested?
Successfully compiled and ran GCHPctm.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
- [x] I have tested this change with a run of GCHPctm (if non-trivial)
- [x] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [ ] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
