### PR TITLE
Allow conservative regridding of vectors

### DIFF
--- a/MAPL_Base/MAPL_ExtDataGridCompMod.F90
+++ b/MAPL_Base/MAPL_ExtDataGridCompMod.F90
@@ -1089,9 +1089,9 @@ CONTAINS
 
          ! check that we are not asking for conservative regridding
 !!$         if (item%Trans /= MAPL_HorzTransOrderBilinear) then
-         if (item%Trans /= REGRID_METHOD_BILINEAR) then
-            _ASSERT(.false.,'No conservative re-gridding with vectors')
-         end if
+         !if (item%Trans /= REGRID_METHOD_BILINEAR) then
+         !   _ASSERT(.false.,'No conservative re-gridding with vectors')
+         !end if
 
          block
             integer :: gridRotation1, gridRotation2


### PR DESCRIPTION
This is a simple modification to comment out a logical check in MAPL_ExtDataGridCompMod which forces a halt if the user tries to perform conservative regridding of a vector quantity. Although it is not clear if this is scientifically valid, we have seen that conservative regridding of wind data (whether vector or scalar) prevents a specific failure mode in regridding and provides a better result than bilinear interpolation under certain circumstances. This update at least removes a block which prevents users from testing this option.