### PR TITLE
Changed lib type from SHARED to STATIC

### DIFF
--- a/gridcomps/CMakeLists.txt
+++ b/gridcomps/CMakeLists.txt
@@ -2,7 +2,7 @@ esma_set_this(OVERRIDE MAPL.gridcomps)
 esma_add_library (${this}
      SRCS MAPL_GridComps.F90
      DEPENDENCIES MAPL.base MAPL.pfio MAPL_cfio_r4 MAPL.cap
-     TYPE SHARED
+     # TYPE SHARED      (in GCHP we want STATIC libs)
      )
 
 target_include_directories (${this} PUBLIC

--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -54,7 +54,9 @@ set (srcs
 
   )
 
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES gftl-shared gftl MAPL.shared MPI::MPI_Fortran TYPE SHARED)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES gftl-shared gftl MAPL.shared MPI::MPI_Fortran 
+  # TYPE SHARED           (in GCHP we want STATIC libs)
+)
 
 target_include_directories (${this} PRIVATE ${MAPL_SOURCE_DIR}/include)
 

--- a/shared/CMakeLists.txt
+++ b/shared/CMakeLists.txt
@@ -27,7 +27,9 @@ set (srcs
     MaplShared.F90
     TimeUtils.F90
   )
-esma_add_library (${this} SRCS ${srcs} DEPENDENCIES gftl-shared MPI::MPI_Fortran pflogger TYPE SHARED)
+esma_add_library (${this} SRCS ${srcs} DEPENDENCIES gftl-shared MPI::MPI_Fortran pflogger 
+  # TYPE SHARED           (in GCHP we want STATIC libs)
+)
 target_include_directories (${this} PUBLIC
           $<BUILD_INTERFACE:${MAPL_SOURCE_DIR}/include>)
 


### PR DESCRIPTION
Removed `TYPE SHARED` arguments to `esma_add_library()` calls for gridcomps, profiler, and shared. These libaries are now static, so we won't have the issue with libraries paths.