### PR TITLE
Atanas Trayanov (GMAO) History updates: monthly diag fix, timestampStart

### DIFF
--- a/base/MAPL_TimeMethods.F90
+++ b/base/MAPL_TimeMethods.F90
@@ -26,6 +26,7 @@ module MAPL_TimeDataMod
      procedure :: compute_time_vector
      procedure :: get_start_time
      procedure :: get
+     procedure :: setFrequency
   end type timeData
 
   interface timeData
@@ -33,19 +34,24 @@ module MAPL_TimeDataMod
   end interface timeData
 contains
 
-  function new_time_data(clock,ntime,frequency,offset,rc) result(tData)
+  function new_time_data(clock,ntime,frequency,offset,funits,rc) result(tData)
     type(timeData) :: tData
     type(ESMF_Clock),intent(inout) :: clock
     integer, intent(in) :: ntime
     integer, intent(in) :: frequency
     type(ESMF_TimeInterval) :: offset
+    character(len=*), optional, intent(in) :: funits
     integer, optional, intent(Out) :: rc
 
     tdata%clock=clock
     tdata%ntime=ntime
     tdata%frequency=frequency
     tdata%offset=offset
-    tdata%funits="minutes"
+    if(present(funits)) then
+       tdata%funits=funits
+    else
+       tdata%funits="minutes"
+    end if
 
     _RETURN(ESMF_SUCCESS)
 
@@ -61,6 +67,15 @@ contains
      _RETURN(_SUCCESS)
   end subroutine get
        
+  subroutine setFrequency(this,frequency,rc)
+     class(TimeData) :: this
+     integer, intent(in) :: frequency
+     integer, optional, intent(out) :: rc
+
+     this%frequency = frequency
+
+     _RETURN(_SUCCESS)
+  end subroutine setFrequency
 
   function define_time_variable(this,rc) result(v)
     class(TimeData), intent(inout) :: this
@@ -98,14 +113,21 @@ contains
     i123=10000*i1+100*i2+i3
     call v%add_attribute('begin_time',i123)
 
-    isc=mod(this%frequency,60)
-    i2=this%frequency-isc
-    i2=i2/60
-    imn=mod(i2,60)
-    i2=i2-imn
-    ihr=i2/60
-    ifreq=10000*ihr+100*imn+isc 
-    call v%add_attribute('time_increment',ifreq)
+    select case(trim(this%funits))
+    case('minutes')
+       isc=mod(this%frequency,60)
+       i2=this%frequency-isc
+       i2=i2/60
+       imn=mod(i2,60)
+       i2=i2-imn
+       ihr=i2/60
+       ifreq=10000*ihr+100*imn+isc 
+    case('days')
+       ifreq = this%frequency/86400
+    case default
+       _ASSERT(.false., 'Not supported yet')
+    end select   
+     call v%add_attribute('time_increment',ifreq)
 
     call this%tvec%clear()
     this%tcount=0

--- a/base/MAPL_newCFIO.F90
+++ b/base/MAPL_newCFIO.F90
@@ -54,6 +54,7 @@ module MAPL_newCFIOMod
         procedure :: CreateFileMetaData
         procedure :: CreateVariable
         procedure :: modifyTime
+        procedure :: modifyTimeIncrement
         procedure :: bundlePost
         procedure :: stageData
         procedure :: stage2DLatLon
@@ -327,6 +328,21 @@ module MAPL_newCFIOMod
         _RETURN(ESMF_SUCCESS)
 
      end subroutine modifyTime
+
+     subroutine modifyTimeIncrement(this, frequency, rc) 
+        class(MAPL_newCFIO), intent(inout) :: this
+        integer, intent(in) :: frequency
+        integer, optional, intent(out) :: rc
+
+        integer :: status
+
+        call this%timeInfo%setFrequency(frequency, rc=status)
+        _VERIFY(status)
+
+        _RETURN(ESMF_SUCCESS)
+
+     end subroutine modifyTimeIncrement
+
 
      subroutine bundlepost(this,filename,oClients,rc)
         class (MAPL_newCFIO), intent(inout) :: this

--- a/gridcomps/History/MAPL_HistoryCollection.F90
+++ b/gridcomps/History/MAPL_HistoryCollection.F90
@@ -66,6 +66,7 @@ module MAPL_HistoryCollectionMod
      integer                            :: Psize
      integer                            :: tm
      logical                            :: ForceOffsetZero
+     logical                            :: timestampStart
      logical                            :: monthly
      logical                            :: partial = .false.
      ! Adding Arithemtic Field Rewrite

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -278,6 +278,9 @@ contains
     type(ESMF_Time)                :: CurrTime
     type(ESMF_Time)                ::  RingTime
     type(ESMF_Time)                ::   RefTime
+    type(ESMF_Time)                :: StartOfThisMonth
+    type(ESMF_Time)                :: nextMonth
+    type(ESMF_TimeInterval)        :: oneMonth, dur
     type(ESMF_TimeInterval)        :: Frequency
     type(ESMF_Array)               :: array
     type(ESMF_Field)               :: field
@@ -482,6 +485,12 @@ contains
     
     nymdc =  year*10000 +  month*100 + day
     nhmsc =  hour*10000 + minute*100 + second
+
+    ! set up few variables to deal with monthly
+    startOfThisMonth = currTime
+    call ESMF_TimeSet(startOfThisMonth,dd=1,h=0,m=0,s=0,__RC__)
+    call ESMF_TimeIntervalSet( oneMonth, MM=1, __RC__)
+
 
 ! Read User-Supplied History Lists from Config File
 ! -------------------------------------------------
@@ -731,12 +740,6 @@ contains
 ! Initialize History Lists
 ! ------------------------
 
-    allocate(INTSTATE%AVERAGE    (nlist), stat=status)
-    _VERIFY(STATUS)
-    allocate(INTSTATE%STAMPOFFSET(nlist), stat=status)
-    _VERIFY(STATUS)
-
-    IntState%average = .false.
     LISTLOOP: do n=1,nlist
 
        list(n)%unit = 0
@@ -1113,6 +1116,10 @@ contains
        call ESMF_ConfigGetAttribute(cfg, list(n)%ForceOffsetZero, default=.false., & 
                                     label=trim(string)//'timestampEnd:', rc=status)
        _VERIFY(status) 
+! Force history so that time averaged collections are timestamped at the begining of the accumulation interval
+       call ESMF_ConfigGetAttribute(cfg, list(n)%timeStampStart, default=.false., & 
+                                    label=trim(string)//'timestampStart:', rc=status)
+       _VERIFY(status)
 
 ! Get an optional chunk size
 ! --------------------------
@@ -1164,15 +1171,6 @@ contains
 
        if (list(n)%disabled) cycle
 
-       if(list(n)%mode == "instantaneous" .or. list(n)%ForceOffsetZero) then
-          sec = 0
-       else
-          IntState%average(n) = .true.
-          sec = MAPL_nsecf(list(n)%acc_interval) / 2
-       endif
-       call ESMF_TimeIntervalSet( INTSTATE%STAMPOFFSET(n), S=sec, rc=status )
-       _VERIFY(STATUS)
-
 ! His and Seg Alarms based on Reference Date and Time
 ! ---------------------------------------------------
        REF_TIME(1) =     list(n)%ref_date/10000
@@ -1182,8 +1180,13 @@ contains
        REF_TIME(5) = mod(list(n)%ref_time,10000)/100
        REF_TIME(6) = mod(list(n)%ref_time,100)
 
-       !ALT if monthly, modify ref_time(4:6)=0
-       if (list(n)%monthly) REF_TIME(4:6) = 0
+       !ALT if monthly, modify ref_time to midnight first of the month
+       if (list(n)%monthly) then
+          REF_TIME(3) = 1
+          REF_TIME(4:6) = 0
+          list(n)%ref_time = 0
+          list(n)%ref_date = 10000*REF_TIME(1) + 100*REF_TIME(2) + REF_TIME(3)
+       end if
        
        call ESMF_TimeSet( RefTime, YY = REF_TIME(1), &
                                    MM = REF_TIME(2), &
@@ -1194,9 +1197,17 @@ contains
 
        ! ALT if monthly, set interval "Frequncy" to 1 month
        ! also in this case sec should be set to non-zero
-       sec = MAPL_nsecf( list(n)%frequency )
-       call ESMF_TimeIntervalSet( Frequency, S=sec, calendar=cal, rc=status ) ; _VERIFY(STATUS)
-       RingTime = RefTime
+       !ALT if monthly overwrite duration and frequency
+       if (list(n)%monthly) then
+          list(n)%duration = 1 !ALT simply non-zero
+          sec = 1              !ALT simply non-zero
+          Frequency = oneMonth
+          RingTime = startOfThisMonth
+       else
+          sec = MAPL_nsecf( list(n)%frequency )
+          call ESMF_TimeIntervalSet( Frequency, S=sec, calendar=cal, rc=status ) ; _VERIFY(STATUS)
+          RingTime = RefTime
+       end if
 
 ! Added Logic to eliminate BEG_DATE = cap_restart date problem
 ! ------------------------------------------------------------
@@ -1214,21 +1225,17 @@ contains
        endif
        _VERIFY(STATUS)
 
-       !ALT if monthly overwrite duration and frequency
-       if (list(n)%monthly) then
-          list(n)%duration = 1 !ALT simply non-zero
-       end if
        if( list(n)%duration.ne.0 ) then
           if (.not.list(n)%monthly) then
              sec = MAPL_nsecf( list(n)%duration )
              call ESMF_TimeIntervalSet( Frequency, S=sec, calendar=cal, rc=status ) ; _VERIFY(STATUS)
-             RingTime = RefTime
           else
-             call ESMF_TimeIntervalSet( Frequency, MM=1, calendar=cal, rc=status ) ; _VERIFY(STATUS)
+             Frequency = oneMonth
              !ALT keep the values from above
              ! and for debugging print
              call WRITE_PARALLEL("DEBUG: monthly averaging is active for collection "//trim(list(n)%collection))
           end if
+          RingTime = RefTime
           if (RingTime < currTime) then
               RingTime = RingTime + (INT((currTime - RingTime)/frequency)+1)*frequency
           endif
@@ -1621,12 +1628,13 @@ ENDDO PARSER
     IntState%average = .false.
     do n=1, nlist
        if (list(n)%disabled) cycle
+       if(list(n)%monthly) cycle
        if(list(n)%mode == "instantaneous" .or. list(n)%ForceOffsetZero) then
           sec = 0
+       else if (list(n)%timeStampStart) then
+          sec = MAPL_nsecf(list(n)%acc_interval)
        else
-          IntState%average(n) = .true.
           sec = MAPL_nsecf(list(n)%acc_interval) / 2
-          if(list(n)%monthly) cycle
        endif
        call ESMF_TimeIntervalSet( INTSTATE%STAMPOFFSET(n), S=sec, rc=status )
        _VERIFY(STATUS)
@@ -2415,7 +2423,14 @@ ENDDO PARSER
           _VERIFY(status)
           call list(n)%mNewCFIO%set_param(itemOrder=intState%fileOrderAlphabetical,rc=status)
           _VERIFY(status)
-          list(n)%timeInfo = TimeData(clock,tm,MAPL_nsecf(list(n)%frequency),IntState%stampoffset(n))
+          if (list(n)%monthly) then
+               nextMonth = currTime - oneMonth
+               dur = nextMonth - currTime
+               call ESMF_TimeIntervalGet(dur, s=sec, __RC__)
+             list(n)%timeInfo = TimeData(clock,tm,sec,IntState%stampoffset(n),'days')
+          else
+             list(n)%timeInfo = TimeData(clock,tm,MAPL_nsecf(list(n)%frequency),IntState%stampoffset(n))
+          end if
           if (list(n)%timeseries_output) then
              list(n)%trajectory = HistoryTrajectory(trim(list(n)%trackfile),rc=status)
              _VERIFY(status)
@@ -2458,12 +2473,20 @@ ENDDO PARSER
          print *, '       Nbits: ',       list(n)%nbits
          print *, '      Slices: ',       list(n)%Slices
          print *, '     Deflate: ',       list(n)%deflate
-         print *, '   Frequency: ',       list(n)%frequency
-         if(IntState%average(n) ) &
+         if (list(n)%monthly) then
+            print *, '   Frequency: ',       'monthly'
+         else
+            print *, '   Frequency: ',       list(n)%frequency
+         end if
+         if(IntState%average(n) .and. .not. list(n)%monthly) &
               print *, 'Acc_Interval: ',  list(n)%acc_interval
          print *, '    Ref_Date: ',       list(n)%ref_date
          print *, '    Ref_Time: ',       list(n)%ref_time
-         print *, '    Duration: ',       list(n)%duration
+         if (list(n)%monthly) then
+            print *, '    Duration: ',       'one month'
+         else
+            print *, '    Duration: ',       list(n)%duration
+         end if
          if( list(n)%end_date.ne.-999 ) then
          print *, '    End_Date: ',       list(n)%end_date
          print *, '    End_Time: ',       list(n)%end_time
@@ -3217,6 +3240,9 @@ ENDDO PARSER
     character(len=ESMF_MAXSTR)     :: DateStamp
     integer                        :: CollBlock
     type(ESMF_Time)                :: current_time
+    type(ESMF_Time)                :: lastMonth
+    type(ESMF_TimeInterval)        :: dur, oneMonth
+    integer                        :: sec
 
 !   variables for "backwards" mode
     logical                        :: fwd
@@ -3438,6 +3464,20 @@ ENDDO PARSER
 
          if( NewSeg) then 
             list(n)%partial = .false.
+            if (list(n)%monthly) then
+               ! get the number of seconds in this month
+               ! it's tempting to use the variable "oneMonth" but it does not work
+               ! instead we compute the differece between 
+               ! thisMonth and lastMonth and as a new timeInterval
+
+               call ESMF_ClockGet(clock,currTime=current_time,rc=status)
+               _VERIFY(status)
+               call ESMF_TimeIntervalSet( oneMonth, MM=1, __RC__)
+               lastMonth = current_time - oneMonth
+               dur = current_time - lastMonth
+               call ESMF_TimeIntervalGet(dur, s=sec, __RC__)
+               call list(n)%mNewCFIO%modifyTimeIncrement(sec, __RC__)
+            end if
          endif
 
          if (list(n)%timeseries_output) then


### PR DESCRIPTION
This PR contains updates from Atanas Trayanov (GMAO) for the following features/bug fixes:

- Diagnostic file time attribute 'time_increment' is now fixed for  monthly diagnostics configured in HISTORY.rc with `collection.monthly: 1`. For monthly time-averaged files it is set to # of days in month.
- Diagnostic filenames can optionally be set to contain start rather than mid-point datetime for time-averaged collections. Configure in HISTORY.rc with `collection.timestampStart: .true.`.

These changes are currently in GEOS-ESM/MAPL branch `develop.` I manually added them to geoschem/MAPL so that we can get them prior to the next MAPL version update in GCHP.

I have tested these changes but have a couple more tests to complete before merging.
