### PR TITLE
Set lev positive 'up' for all collections except Emissions

### DIFF
--- a/base/MAPL_VerticalMethods.F90
+++ b/base/MAPL_VerticalMethods.F90
@@ -272,10 +272,11 @@ module MAPL_VerticalDataMod
      end subroutine get_interpolating_variable
 
 
-     subroutine append_vertical_metadata(this,metadata,bundle,rc)
+     subroutine append_vertical_metadata(this,metadata,bundle,posDown,rc)
         class (verticalData), intent(inout) :: this
         type(FileMetaData), intent(inout) :: metadata
         type(ESMF_FieldBundle), intent(inout) :: bundle
+        logical, optional, intent(in) :: posDown ! Added for GCHP
         integer, optional, intent(out) :: rc
 
         integer :: lm,i,NumVars,fieldRank,vlast,vloc,vlb
@@ -296,6 +297,12 @@ module MAPL_VerticalDataMod
         integer :: status
         type(Variable) :: v
         logical :: isPresent
+
+        logical :: isPosDown ! Added for GCHP
+
+        ! Added for GCHP
+        isPosDown = .TRUE.
+        if (present(posDown)) isPosDown = posDown
 
         ! loop over variables in file
         call ESMF_FieldBundleGet(bundle,fieldCount=NumVars,rc=status)
@@ -438,7 +445,11 @@ module MAPL_VerticalDataMod
                  v = Variable(type=PFIO_REAL64, dimensions='lev')
                  call v%add_attribute('long_name','vertical level')
                  call v%add_attribute('units','layer')
-                 call v%add_attribute('positive','down')
+                 if (isPosDown) then
+                     call v%add_attribute('positive','down')
+                 else
+                     call v%add_attribute('positive','up')
+                 endif
                  call v%add_attribute('coordinate','eta')
                  call v%add_attribute('standard_name','model_layer')
                  call v%add_const_value(UnlimitedEntity(this%levs))

--- a/base/MAPL_newCFIO.F90
+++ b/base/MAPL_newCFIO.F90
@@ -99,13 +99,14 @@ module MAPL_newCFIOMod
         _RETURN(ESMF_SUCCESS)
      end function new_MAPL_newCFIO
 
-     subroutine CreateFileMetaData(this,items,bundle,timeInfo,vdata,ogrid,rc)
+     subroutine CreateFileMetaData(this,items,bundle,timeInfo,vdata,ogrid,posDown,rc)
         class (MAPL_newCFIO), intent(inout) :: this
         type(newCFIOitemVector), target, intent(inout) :: items
         type(ESMF_FieldBundle), intent(inout) :: bundle
         type(TimeData), intent(inout) :: timeInfo
         type(VerticalData), intent(inout), optional :: vdata
         type (ESMF_Grid), intent(inout), pointer, optional :: ogrid
+        logical, intent(in), optional :: posDown ! Added for GCHP
         integer, intent(out), optional :: rc
 
         type(ESMF_Grid) :: input_grid
@@ -117,6 +118,11 @@ module MAPL_newCFIOMod
         integer :: metadataVarsSize
 
         integer :: status
+        logical :: isPosDown ! Added for GCHP
+
+        ! Added for GCHP
+        isPosDown = .TRUE.
+        if (present(posDown)) isPosDown = posDown
 
         this%items = items
         this%input_bundle = bundle
@@ -145,7 +151,7 @@ module MAPL_newCFIOMod
            this%vdata=VerticalData(rc=status)
            _VERIFY(status)
         end if
-        call this%vdata%append_vertical_metadata(this%metadata,this%input_bundle,rc=status)
+        call this%vdata%append_vertical_metadata(this%metadata,this%input_bundle,posDown=isPosDown,rc=status)
         _VERIFY(status)
         this%doVertRegrid = (this%vdata%regrid_type /= VERTICAL_METHOD_NONE)
         if (this%vdata%regrid_type == VERTICAL_METHOD_ETA2LEV) call this%vdata%get_interpolating_variable(this%input_bundle,rc=status)

--- a/gridcomps/History/MAPL_HistoryGridComp.F90
+++ b/gridcomps/History/MAPL_HistoryGridComp.F90
@@ -409,6 +409,7 @@ contains
     integer              :: chnksz
     logical :: table_end
     logical :: old_fields_style
+    logical :: isPosDown ! Added for GCHP
 
     type(HistoryCollection) :: collection
     character(len=ESMF_MAXSTR) :: cFileOrder
@@ -2442,7 +2443,10 @@ ENDDO PARSER
                 call list(n)%mNewCFIO%CreateFileMetaData(list(n)%items,list(n)%bundle,list(n)%timeInfo,ogrid=pgrid,vdata=list(n)%vdata,rc=status)
                 _VERIFY(status)
              else
-                call list(n)%mNewCFIO%CreateFileMetaData(list(n)%items,list(n)%bundle,list(n)%timeInfo,vdata=list(n)%vdata,rc=status)
+                ! Set lev positive to down for Emissions collection in GCHP
+                isPosDown = .TRUE.
+                if ( trim(list(n)%collection) /= "Emissions" ) isPosDown = .FALSE.
+                call list(n)%mNewCFIO%CreateFileMetaData(list(n)%items,list(n)%bundle,list(n)%timeInfo,vdata=list(n)%vdata,posDown=isPosDown,rc=status)
                 _VERIFY(status)
              end if
              collection_id = o_Clients%add_hist_collection(list(n)%mNewCFIO%metadata)


### PR DESCRIPTION
This PR is a quick fix to issue https://github.com/geoschem/GCHP/issues/112. With this update the `lev` dimension `positive` attribute in History (diagnostic) files is set to `up` for all collections except Emissions which remains `down`. Previously all collection output files were set to `down` by default which is correct for GEOS but not GCHP.