### PR TITLE
Fixes geoschem/GCHP#118

### DIFF
--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -12,5 +12,5 @@ install (PROGRAMS
   MAPL_GridCompSpecs_ACG.py
   mapl_acg.pl
   mapl_stub.pl
-  TYPE SYSCONF
+  DESTINATION etc
   )

--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -12,5 +12,9 @@ install (PROGRAMS
   MAPL_GridCompSpecs_ACG.py
   mapl_acg.pl
   mapl_stub.pl
+  # [lrb, 2021-7-22] For GCHP: Replaced TYPE arg with DESTINATION. The TYPE 
+  #                            argument wasn't added until CMake 3.14 and our
+  #                            current requirement is 3.13.
+- # TYPE SYSCONF
   DESTINATION etc
   )


### PR DESCRIPTION
Fixes https://github.com/geoschem/GCHP/issues/118. 

The `TYPE` keyword argument to `install(PROGRAMS)` was introduced in 3.14. To avoid the need to increase `cmake_minimum_required(3.14)` we should use `DESTINATION` rather than `TYPE`. 

According to [2] the default `DESTINATION` for `TYPE SYSCONF` is `etc`. Therefore, this PR changes the MAPL/Apps `install()` command to specify `DESTINATION etc`.  


## Refs
1. https://cmake.org/cmake/help/v3.13/command/install.html#programs
2. https://cmake.org/cmake/help/v3.14/command/install.html#programs