### PR TITLE
Intuitive error when untemplated file is missing

### DIFF
--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -12,9 +12,5 @@ install (PROGRAMS
   MAPL_GridCompSpecs_ACG.py
   mapl_acg.pl
   mapl_stub.pl
-  # [lrb, 2021-7-22] For GCHP: Replaced TYPE arg with DESTINATION. The TYPE 
-  #                            argument wasn't added until CMake 3.14 and our
-  #                            current requirement is 3.13.
-- # TYPE SYSCONF
-  DESTINATION etc
+  TYPE SYSCONF
   )

--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -12,5 +12,5 @@ install (PROGRAMS
   MAPL_GridCompSpecs_ACG.py
   mapl_acg.pl
   mapl_stub.pl
-  TYPE SYSCONF
+  DESTINATION etc
   )

--- a/Apps/CMakeLists.txt
+++ b/Apps/CMakeLists.txt
@@ -12,5 +12,9 @@ install (PROGRAMS
   MAPL_GridCompSpecs_ACG.py
   mapl_acg.pl
   mapl_stub.pl
+  # [lrb, 2021-7-22] For GCHP: Replaced TYPE arg with DESTINATION. The TYPE 
+  #                            argument wasn't added until CMake 3.14 and our
+  #                            current requirement is 3.13.
+- # TYPE SYSCONF
   DESTINATION etc
   )

--- a/base/MAPL_ExtDataGridCompMod.F90
+++ b/base/MAPL_ExtDataGridCompMod.F90
@@ -2145,6 +2145,7 @@ CONTAINS
 
            file = item%file
            Inquire(file=trim(file),EXIST=found)
+           _ASSERT(found,'File ' // trim(item%file) // ' not found')
 
         else
            buff = trim(item%refresh_template)


### PR DESCRIPTION
If a file is missing for which the template in ExtData.rc has no time-based tokens, the result is a very unintuitive error out of ESMF_TimeGet. This pull request should fix that issue, explicitly throwing an error if a file which has no frequency tokens is not found. This file does not appear to be in the MAPL main branch any longer, so the pull request had to come here.

- [ ] I have tested this change with a run of GCHP
