### PR TITLE
Move call to CreateTimeInterval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated `components.yaml`. These changes are to support using Spack to build MAPL
   - ESMA_cmake v3.10.0 (add `FindESMF.cmake` from NOAA-EMC)
   - ecbuild geos/v1.2.0 (updat `FindNetCDF.cmake` to that from NOAA-EMC)
-- File not found error handling in ExtData improved for non-templated filenames
+- Improved file-not-found error handling in ExtData for non-templated filenames
 
 ## [2.17.2] - 2022-02-16
 

--- a/gridcomps/ExtData/ExtDataGridCompMod.F90
+++ b/gridcomps/ExtData/ExtDataGridCompMod.F90
@@ -675,10 +675,6 @@ CONTAINS
                            primary%item(totalPrimaryEntries)%cyclic='n'
                         end if
 
-
-                        if ( primary%item(totalPrimaryEntries)%isConst .eqv. .false. )  then
-                           call CreateTimeInterval(primary%item(totalPrimaryEntries),clock,__RC__)
-                        end if
                      end if
                   enddo
                !  Derived Exports
@@ -911,6 +907,10 @@ CONTAINS
 
       call lgr%debug('ExtData Initialize_(): PrimaryLoop: ')
 
+      if ( .not. item%isConst )  then
+         call CreateTimeInterval(item,clock,__RC__)
+      end if
+      
       item%pfioCollection_id = MAPL_DataAddCollection(item%file,use_file_coords=self%use_file_coords)
 
       ! parse refresh template to see if we have a time shift during constant updating


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

While looking at https://github.com/GEOS-ESM/MAPL/pull/1377 by @lizziel, it was found that her check was a bit too powerful for GEOS in that we have some bugs in our ExtData files. But, @bena-nasa looked at the code and found that we were doing `CreateTimeInterval` at the wrong time. Previously, we were doing it during the phase of ExtData when the *entire* `ExtData.rc` file is processed. Instead, we move the call to the loop where ExtData works on the actual Imports it will be handling.

@lizziel Can you make sure this change works with GCHP? I know it does with GEOS, but I decided to respect the process and make my PR on your branch and if you accept it, then it'll get pull to the mothership MAPL as well.

## Related Issue
<!--- This project primarily accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GCHP
