### PR TITLE
Patch to fix MPI communicators leak in ExtData

### DIFF
--- a/pfio/AbstractServer.F90
+++ b/pfio/AbstractServer.F90
@@ -130,7 +130,7 @@ contains
       integer :: ierror, MyColor
       character(len=:), allocatable :: p_name
 
-      call MPI_Comm_dup(comm, this%comm, ierror)
+      this%comm = comm
 
       call MPI_Comm_rank(this%comm, this%rank, ierror)
       call MPI_Comm_size(this%comm, this%npes, ierror)

--- a/pfio/ClientManager.F90
+++ b/pfio/ClientManager.F90
@@ -105,7 +105,7 @@ contains
         clientPtr=>null()
       enddo
 
-      call Mpi_Comm_dup(client_comm, c_manager%client_comm, rc)
+      c_manager%client_comm = client_comm
       call MPI_Comm_rank(client_comm, c_manager%rank, rc)
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)

--- a/pfio/DirectoryService.F90
+++ b/pfio/DirectoryService.F90
@@ -595,7 +595,7 @@ contains
          call c_f_pointer(this%client_dir, dir)
          call MPI_Free_mem(dir, ierror)
       end if
-
+      call Mpi_Comm_free(this%comm, ierror)
       _RETURN(_SUCCESS)
    end subroutine free_directory_resources
 

--- a/pfio/MpiMutex.F90
+++ b/pfio/MpiMutex.F90
@@ -168,6 +168,7 @@ contains
          call c_f_pointer(this%locks_ptr, scratchpad, [this%npes])
          call MPI_Free_mem(scratchpad, ierror)
       end if
+      call Mpi_comm_free(this%comm, ierror)
 
    end subroutine free_mpi_resources
 

--- a/pfio/MultiCommServer.F90
+++ b/pfio/MultiCommServer.F90
@@ -89,7 +89,7 @@ contains
       type (MpiSocket), target :: dummy_socket
       integer, allocatable :: node_sizes(:)
 
-      call MPI_Comm_dup(server_comm, s%server_comm, ierror)
+      s%server_comm = server_comm
       call MPI_Comm_size(s%server_comm, s_size , ierror)
       
       splitter = SimpleCommsplitter(s%server_comm)

--- a/pfio/MultiGroupServer.F90
+++ b/pfio/MultiGroupServer.F90
@@ -104,7 +104,7 @@ contains
       integer, allocatable :: ranks(:)
       integer, allocatable :: node_sizes(:)
 
-      call MPI_Comm_dup(server_comm, s%server_comm, ierror)
+      s%server_comm = server_comm
       call MPI_Comm_size(s%server_comm, s_size , ierror)
 
       splitter = SimpleCommsplitter(s%server_comm)

--- a/pfio/RDMAReference.F90
+++ b/pfio/RDMAReference.F90
@@ -144,6 +144,8 @@ contains
          _VERIFY(status)
          call MPI_Win_free(this%win,status)
          _VERIFY(status)
+         call MPi_comm_free(this%comm, status)
+         _VERIFY(status)
       endif
 
       this%RDMA_allocated = .false.

--- a/pfio/ShmemReference.F90
+++ b/pfio/ShmemReference.F90
@@ -142,7 +142,7 @@ contains
 
       call MPI_Win_fence(0, this%win, ierr)
       call MPI_Win_free(this%win,ierr)
-
+      call MPI_Comm_free(this%InNode_Comm, ierr)
       this%shmem_allocated = .false.
       _RETURN(_SUCCESS)
    end subroutine deallocate


### PR DESCRIPTION
## Description
This PR fixes a communicator leak in MAPL that causes GCHP to crash with a "Too many communicators" error message for some MPIs during the ExtData Run stage. This fix was provided as a patch by GMAO for MAPL 2.6.3 (the version used in GCHP 13). It has already been fixed in more recent versions of MAPL.

## Related Issue
https://github.com/GEOS-ESM/MAPL/issues/1232
Closes https://github.com/geoschem/GCHP/issues/187

## How Has This Been Tested?
Users report this patch fixes the problem.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have tested this change with a run of GCHP
