### PR TITLE
Fix bug in setting target stretched grid lat/lon from restart file

### DIFF
--- a/base/MAPL_CubedSphereGridFactory.F90
+++ b/base/MAPL_CubedSphereGridFactory.F90
@@ -338,7 +338,7 @@ contains
          attr_val => attr%get_values()
          select type(q=>attr_val)
          type is (real(kind=REAL32))
-            this%target_lon = q(1)
+            this%target_lat = q(1)
          class default
             _ASSERT(.false.,'unsupport subclass for stretch params')
          end select
@@ -346,7 +346,7 @@ contains
          attr_val => attr%get_values()
          select type(q=>attr_val)
          type is (real(kind=REAL32))
-            this%target_lat = q(1)
+            this%target_lon = q(1)
          class default
             _ASSERT(.false.,'unsupport subclass for stretch params')
          end select


### PR DESCRIPTION
Stretched grid target latitude and longitude are incorrectly assigned when setting them from restart file metadata. Target lat is set to lon, and lon is set to lat. This bug only impacts running with stretched grid using target latitude and longitude from restart file metadata which is only relevant for GCHP 14.0 and beyond.

This fix was submitted by @LiamBindle.

closes https://github.com/geoschem/GCHP/issues/246