### PR TITLE
[FEATURE] Expand netcdf get var error handling

### DIFF
--- a/pfio/NetCDF4_FileFormatter.F90
+++ b/pfio/NetCDF4_FileFormatter.F90
@@ -27,6 +27,7 @@ module pFIO_NetCDF4_FileFormatterMod
    include 'mpif.h'
    type :: NetCDF4_FileFormatter
 !$$      private
+      character(len=:), allocatable :: origin_file
       integer :: ncid = -1
       logical :: parallel = .false.
       integer :: comm = -1
@@ -277,6 +278,8 @@ contains
       end if
       !$omp end critical
       _VERIFY(status)
+
+      this%origin_file = file
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)

--- a/pfio/NetCDF4_get_var.H
+++ b/pfio/NetCDF4_get_var.H
@@ -26,7 +26,8 @@
       status = nf90_inq_varid(this%ncid, name=var_name, varid=varid)
      !$omp end critical
 
-     _ASSERT(status==0,"Variable not found: "//trim(var_name)) 
+     _ASSERT(status==0,"Variable not found: "//trim(var_name)//" in file: "//trim(this%origin_file))
+
      !$omp critical
 #if (_RANK == 0)
       status = nf90_get_var(this%ncid, varid, values)
@@ -34,7 +35,8 @@
       status = nf90_get_var(this%ncid, varid, values, start, count)
 #endif
      !$omp end critical
-      _VERIFY(status)
+
+     _ASSERT(status==0,"Unable to get variable: "//trim(var_name)//" from file: "//trim(this%origin_file))
 
       _RETURN(_SUCCESS)
       _UNUSED_DUMMY(unusable)


### PR DESCRIPTION
<!--- These lines are comments. You can delete or ignore them -->
<!--- NOTE: If your PR is trivial, feel free to delete the "Related Issue" -->
<!---       "Testing" or other sections. -->

<!--- Provide a general summary of your changes in the Title above -->
This update expands the error handling in the macro within `NetCDF4_get_var.H` which retrieves data from netcdf files. It adds an assert statement following the attempt to get values for a variable from file. If the status indicates a problem then a helpful message is printed containing the variable name and filename that was trying to be accessed.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Corrupted input files may result in a bad status code after calling function nf90_get_var. Users get tripped up by this since there are no messages automatically printed that indicate the variable that is causing the issue.
