### PR TITLE
More elegant fix for stretched grid checkpoint bug fixed in 14.1.1

### DIFF
--- a/base/NCIO.F90
+++ b/base/NCIO.F90
@@ -3258,12 +3258,6 @@ module NCIOMod
     character(len=ESMF_MAXSTR) :: positive
     type(StringVector) :: flip_vars
 
-    ! Hack for fixing checkpoint target lat and lon (ewl)
-    integer :: IU_GEOS, IOS, N
-    character(len=ESMF_MAXSTR) :: LINE, SUBSTRS(500)
-    character(len=ESMF_MAXSTR) :: target_lon_deg_str, target_lat_deg_str
-    real(KIND=ESMF_KIND_R4) :: target_lon_deg, target_lat_deg
-
     call ESMF_FieldBundleGet(Bundle,FieldCount=nVars, name=BundleName, rc=STATUS)
     _VERIFY(STATUS)
 
@@ -3284,28 +3278,6 @@ module NCIOMod
     else
        is_stretched = .false.
     end if
-
-    ! Hack for fixing checkpoint global attribute (ewl)
-    if ( is_stretched ) then
-       target_lon_deg_str = ''
-       target_lat_deg_str = ''
-       open( iu_geos, file='GCHP.rc', STATUS='OLD', IOSTAT=IOS )
-       do
-          read( iu_geos, '(a)', IOSTAT=IOS ) line
-          line = ADJUSTL( ADJUSTR( line ) )
-          if ( INDEX( line, 'TARGET_LON' ) > 0 ) THEN
-             target_lon_deg_str = line(INDEX(line,':')+2:len(trim(line)))
-             read( target_lon_deg_str, '(f5.6)' ) target_lon_deg
-          endif
-          if ( INDEX( line, 'TARGET_LAT' ) > 0 ) THEN
-             target_lat_deg_str = line(INDEX(line,':')+2:len(trim(line)))
-             read( target_lat_deg_str, '(f4.6)' ) target_lat_deg
-          endif
-          if ( ( LEN(TRIM(target_lon_deg_str)) > 0 ) .AND. &
-               ( LEN(TRIM(target_lat_deg_str)) > 0 ) ) EXIT
-       enddo
-       close( iu_geos )
-    endif
 
     ! verify that file is compatible with fields in bundle we are reading
 
@@ -3489,10 +3461,8 @@ module NCIOMod
              x0=1.0d0
              x1=dble(arrdes%IM_WORLD)
              if (is_stretched) then
-                !call cf%add_attribute('TARGET_LON',target_lon)
-                !call cf%add_attribute('TARGET_LAT',target_lat)
-                call cf%add_attribute('TARGET_LON',target_lon_deg)
-                call cf%add_attribute('TARGET_LAT',target_lat_deg)
+                call cf%add_attribute('TARGET_LON',target_lon*180.0/MAPL_PI)
+                call cf%add_attribute('TARGET_LAT',target_lat*180.0/MAPL_PI)
                 call cf%add_attribute('STRETCH_FACTOR',stretch_factor)
              end if
           else


### PR DESCRIPTION
This PR replaces the previous fix for the GCHP checkpoint attribute issue that was preventing restarting GCHP with a stretched grid restart file. That fix went into 14.1.1. This new fix causes zero diff with 14.1.1 stretched grid simulations.

The previous fix was a hack to read in the config file when putting together a checkpoint file. The new fix is a simple conversion from radians to degrees before writing the target_lat/lon attributes. This approach previously did not work because the MAPL_RADIANS_TO_DEGREE parameter inserts the wrong order of operations for the conversion. The new fix effectively multiplies by 180.0 and then divides by MAPL_PI, avoiding a small bias introduced if multiplying by (180.0/MAPL_PI). This preserves the same value as the target lat/lon read from the config file.

Related issues:

https://github.com/geoschem/GCHP/issues/287
GEOS-ESM/MAPL https://github.com/GEOS-ESM/MAPL/issues/1977

