### PR TITLE
Set ESMF logging mode at run-time via config file

### DIFF
--- a/gridcomps/Cap/MAPL_Cap.F90
+++ b/gridcomps/Cap/MAPL_Cap.F90
@@ -273,10 +273,22 @@ contains
       integer(kind=INT64) :: start_tick, stop_tick, tick_rate
       integer :: status
       class(Logger), pointer :: lgr
+      logical :: file_exists
       
       _UNUSED_DUMMY(unusable)
 
       call start_timer()
+
+      ! Look for a file called "ESMF.rc"
+      inquire(file='ESMF.rc', exist=file_exists)
+
+      ! If the file exists, we pass it into ESMF_Initialize, else, we
+      ! use the one from the command line arguments
+      if (file_exists) then
+         call ESMF_Initialize (configFileName='ESMF.rc', mpiCommunicator=comm, _RC)
+      else
+         call ESMF_Initialize (logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, _RC)
+      end if
 
       call ESMF_Initialize (logKindFlag=this%cap_options%esmf_logging_mode, mpiCommunicator=comm, rc=status)
       _VERIFY(status)


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard University

### Confirm you have reviewed the following documentation

- [X] [Contributing guidelines](https://gchp.readthedocs.io/en/latest/reference/CONTRIBUTING.html)

### Describe the update

This update was developed by Matt Thompson (NASA GMAO). Previously the ESMF logging option had to be set in cap_options at compile time in GCHP. With the update it is read from config file `ESMF.rc` at run-time. This prevents having to recompile the model when changing the ESMF logging mode. 

### Expected changes

MAPL now expects config file `ESMF.rc`.

### Reference(s)

None

### Related Github Issue(s)

- https://github.com/GEOS-ESM/MAPL/issues/2133

### Related PRs

- https://github.com/geoschem/GCHP/pull/330
- https://github.com/geoschem/geos-chem/pull/1879
