### PR TITLE
Add debug-level printout for CAP.EXTDATA to show container name being read from ExtData.rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 ### Added
+- Add debug logger call to print out the name of the container being read from `ExtData.rc`
 
 ### Changed
 

--- a/gridcomps/ExtData/ExtDataGridCompMod.F90
+++ b/gridcomps/ExtData/ExtDataGridCompMod.F90
@@ -1,3 +1,4 @@
+
 !#include "MAPL_Exceptions.h"
 #include "MAPL_Generic.h"
 #include "unused_dummy.H"
@@ -551,7 +552,8 @@ CONTAINS
                      if (trim(thisLine) == "%%") then
                         inBlock = .false.
                      else
-
+                        call lgr%debug('Reading this data container: %a', trim(thisLine))
+                        print*, 'Reading this line: ', trim(thisLine)
                         totalPrimaryEntries = totalPrimaryEntries + 1
                         ! name entry
                         primary%item(totalPrimaryEntries)%name = trim(thisLine)

--- a/gridcomps/ExtData/ExtDataGridCompMod.F90
+++ b/gridcomps/ExtData/ExtDataGridCompMod.F90
@@ -553,7 +553,6 @@ CONTAINS
                         inBlock = .false.
                      else
                         call lgr%debug('Reading this data container: %a', trim(thisLine))
-                        print*, 'Reading this line: ', trim(thisLine)
                         totalPrimaryEntries = totalPrimaryEntries + 1
                         ! name entry
                         primary%item(totalPrimaryEntries)%name = trim(thisLine)


### PR DESCRIPTION
## Description
This PR adds a debug logger call to print out the name of the data container being read from ExtData.rc.

## Related Issue
closes https://github.com/geoschem/MAPL/issues/30

## Motivation and Context
Currently, MAPL does not include this information in when setting the `CAP.EXTDATA` settings to `DEBUG` mode.  This can make it difficult to diagnose and find issues caused by improperly-formatted netCDF files.

## How Has This Been Tested?
I have tested this with a GCHP simulation with `CAP.EXTDATA` options set to `DEBUG` in `logging.yml`.  This is the output:

```console
0000: CAP.EXTDATA: DEBUG: Reading this data container: ALBD
0001: CAP.EXTDATA: DEBUG: Reading this data container: ALBD
0002: CAP.EXTDATA: DEBUG: Reading this data container: ALBD
0003: CAP.EXTDATA: DEBUG: Reading this data container: ALBD
0004: CAP.EXTDATA: DEBUG: Reading this data container: ALBD
0005: CAP.EXTDATA: DEBUG: Reading this data container: ALBD
0000: CAP.EXTDATA: DEBUG: Reading this data container: CLDFRC
0001: CAP.EXTDATA: DEBUG: Reading this data container: CLDFRC
0002: CAP.EXTDATA: DEBUG: Reading this data container: CLDFRC
0003: CAP.EXTDATA: DEBUG: Reading this data container: CLDFRC
0004: CAP.EXTDATA: DEBUG: Reading this data container: CLDFRC
0005: CAP.EXTDATA: DEBUG: Reading this data container: CLDFRC
0000: CAP.EXTDATA: DEBUG: Reading this data container: EFLUX
0001: CAP.EXTDATA: DEBUG: Reading this data container: EFLUX
0002: CAP.EXTDATA: DEBUG: Reading this data container: EFLUX
0003: CAP.EXTDATA: DEBUG: Reading this data container: EFLUX
0004: CAP.EXTDATA: DEBUG: Reading this data container: EFLUX
0005: CAP.EXTDATA: DEBUG: Reading this data container: EFLUX
... etc ...
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Trivial change (affects only documentation or cleanup)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have tested this change with a run of GEOSgcm (if non-trivial)
- [ ] I have added one of the required labels (0 diff, 0 diff trivial, 0 diff structural, non 0-diff)
- [x] I have updated the CHANGELOG.md accordingly following the style of [Keep a Changelog](https://keepachangelog.com/en/1.0.0/#how)
