### PR TITLE
Bug fix for stretched grid restart attribute check

### DIFF
--- a/base/MAPL_CubedSphereGridFactory.F90
+++ b/base/MAPL_CubedSphereGridFactory.F90
@@ -640,8 +640,8 @@ contains
          _ASSERT(this%target_lat >= -90.0, 'Latitude should be greater than -90.0 degrees')
          _ASSERT(this%target_lat <= 90, 'Latitude should be less than 90.0 degrees')
          this%stretched_cube = .true.
-         this%target_lon=this%target_lon*pi/180.d0
-         this%target_lat=this%target_lat*pi/180.d0
+         this%target_lon=this%target_lon*MAPL_PI/180.0
+         this%target_lat=this%target_lat*MAPL_PI/180.0
       end if
 
       ! Check decomposition/bounds


### PR DESCRIPTION
This PR fixes a mismatch between stretched grid coordinates as computed from attributes in the restart file and in the configure files. Target lat/lon are read from file as REAL4 and written to checkpoint as REAL4. Conversion to radians, however, uses 180 degrees at double precision, while conversion back to lat/lon uses 180 degrees as single precision. This results in failing the online check that the coordinates are identical.

Please note that MAPL will have a major overhaul to MAPL3 soon. I am therefore applying the simplest fix to our fork only rather than change MAPL to compare lat/lon instead radians. However, I will check that the bug is not present in the MAPL3 development code.

closes https://github.com/geoschem/GCHP/issues/404


