### PR TITLE
Vertically flip imports with dimensionless pressure proxy lev coordinates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Add debug logger call to print out the name of the container being read from `ExtData.rc`
+- Added dimensionless vertical coordinates to criteria for vertically flipping imports in ExtData
 
 ### Changed
 

--- a/base/FileMetadataUtilities.F90
+++ b/base/FileMetadataUtilities.F90
@@ -490,20 +490,23 @@ module MAPL_FileMetadataUtilsMod
 
    end function get_variable_attribute
 
-   subroutine get_coordinate_info(this,coordinate_name,coordSize,coordUnits,coords,rc)
+   subroutine get_coordinate_info(this,coordinate_name,coordSize,coordUnits,coordStandardName,coords,rc)
       class (FileMetadataUtils), intent(inout) :: this
       character(len=*), intent(in) :: coordinate_name
       integer, optional, intent(out) :: coordSize
       character(len=*), optional, intent(out) :: coordUnits
+      character(len=*), optional, intent(out) :: coordStandardName
       real, allocatable, optional,  intent(inout) :: coords(:)
       integer, optional, intent(out) :: rc
 
       integer :: status
+      logical :: isPresent
       character(:), allocatable :: fname
       class(CoordinateVariable), pointer :: var
       type(Attribute), pointer :: attr
       character(len=:), pointer :: vdim
       class(*), pointer :: coordUnitPtr
+      class(*), pointer :: coordStandardNamePtr
       class(*), pointer :: ptr(:)
  
       fname = this%get_file_name(_RC)
@@ -525,6 +528,23 @@ module MAPL_FileMetadataUtilsMod
             _FAIL('coordinate units must be string in '//fname)
          end select
       end if 
+
+      if (present(coordStandardName)) then
+         ! Allow for missing standard_name
+         isPresent = var%is_attribute_present('standard_name')
+         if ( isPresent) then
+            attr => var%get_attribute('standard_name')
+            coordStandardNamePtr => attr%get_value()
+            select type(coordStandardNamePtr)
+            type is (character(*))
+               coordStandardName = trim(coordStandardNamePtr)
+            class default
+               _FAIL('coordinate standard name must be string in '//fname)
+            end select
+         else
+            coordStandardName = 'missing'
+         endif
+      end if
 
       if (present(coords)) then
          ptr => var%get_coordinate_data()

--- a/gridcomps/ExtData/ExtDataGridCompMod.F90
+++ b/gridcomps/ExtData/ExtDataGridCompMod.F90
@@ -154,6 +154,7 @@
      character(len=4)             :: importVDir = "down"
      character(len=4)             :: fileVDir = "down"
      character(len=ESMF_MAXSTR)   :: levUnit
+     character(len=ESMF_MAXSTR)   :: levStandardName
      logical                      :: havePressure = .false.
   end type PrimaryExport
 
@@ -2087,6 +2088,7 @@ CONTAINS
         type(ESMF_Field)           :: field
         real, allocatable          :: levFile(:)
         character(len=ESMF_MAXSTR) :: buff,levunits,tlevunits,temp_name
+        character(len=ESMF_MAXSTR) :: levstandardname,tlevstandardname
         logical                    :: found,lFound,intOK
         integer                    :: maxOffset
         character(len=:), allocatable :: levname
@@ -2194,15 +2196,29 @@ CONTAINS
         levName = metadata%get_level_name(rc=status)
         _VERIFY(status)
         if (trim(levName) /='') then
-           call metadata%get_coordinate_info(levName,coordSize=item%lm,coordUnits=tLevUnits,coords=levFile,__RC__)
+           call metadata%get_coordinate_info(levName,coordSize=item%lm,coordUnits=tLevUnits, &
+                coordStandardName=tLevStandardName,coords=levFile,__RC__)
            ! GCHP: use trim to avoid gfortran issue
            !levUnits=MAPL_TrimString(tlevUnits)
            levUnits=trim(tlevUnits)
-           ! check if pressure
+           ! check if vertical coordinate is pressure or dimensionless pressure proxy
            item%levUnit = ESMF_UtilStringLowerCase(levUnits)
-           if (trim(item%levUnit) == 'hpa' .or. trim(item%levUnit)=='pa') then
+           if ( ( trim(item%levUnit) == 'hpa' ) .or. &
+                ( trim(item%levUnit) =='pa' ) .or. &
+                ( trim(item%levUnit) == 'sigma_level' ) ) then
               item%havePressure = .true.
-           end if
+           elseif ( trim(levStandardName) /= 'missing' ) then
+              ! check standard_name attribute to catch cases where lev values are
+              ! dimensionless vertical coordinates as proxy for pressure
+              levStandardName= trim(tlevStandardName)
+              item%levStandardName = ESMF_UtilStringLowerCase(levStandardName)
+              if ( ( index(trim(item%levStandardName),"atmosphere_hybrid_sigma_pressure_coordinate") > 0 ) .or. &
+                   ( index(trim(item%levStandardName),"atmosphere_sigma_coordinate") > 0 ) .or. &
+                   ( index(trim(item%levStandardName),"atmosphere_ln_pressure_coordinate") > 0 ) ) then
+                 item%havePressure = .true.
+              endif
+           endif
+
            if (item%havePressure) then
               if (levFile(1)>levFile(size(levFile))) item%fileVDir="up"
            else

--- a/gridcomps/ExtData2G/ExtDataGridCompNG.F90
+++ b/gridcomps/ExtData2G/ExtDataGridCompNG.F90
@@ -924,6 +924,7 @@ CONTAINS
 
         real, allocatable          :: levFile(:)
         character(len=ESMF_MAXSTR) :: levunits,tlevunits
+        character(len=ESMF_MAXSTR) :: levstandardname,tlevstandardname
         character(len=:), allocatable :: levname
         character(len=:), pointer :: positive
         type(Variable), pointer :: var
@@ -945,12 +946,25 @@ CONTAINS
         levName = item%file_metadata%get_level_name(rc=status)
         _VERIFY(status)
         if (trim(levName) /='') then
-           call item%file_metadata%get_coordinate_info(levName,coordSize=item%lm,coordUnits=tLevUnits,coords=levFile,_RC)
+           call item%file_metadata%get_coordinate_info(levName,coordSize=item%lm,coordUnits=tLevUnits, &
+                coordStandardName=tLevStandardName,coords=levFile,_RC)
            levUnits=MAPL_TrimString(tlevUnits)
-           ! check if pressure
+           ! check if vertical coordinate is pressure or dimensionless pressure proxy
            item%levUnit = ESMF_UtilStringLowerCase(levUnits)
-           if (trim(item%levUnit) == 'hpa' .or. trim(item%levUnit)=='pa') then
+           if ( ( trim(item%levUnit) == 'hpa' ) .or. &
+                ( trim(item%levUnit) == 'pa' ) .or. &
+                ( trim(item%levUnit) == 'sigma_level' ) ) then
               item%havePressure = .true.
+           elseif ( trim(levStandardName) /= 'missing' ) then
+              ! check standard_name attribute to catch cases where lev values are
+              ! dimensionless vertical coordinates as proxy for pressure
+              levStandardName= trim(tlevStandardName)
+              item%levStandardName = ESMF_UtilStringLowerCase(levStandardName)
+              if ( ( index(trim(item%levStandardName),"atmosphere_hybrid_sigma_pressure_coordinate") > 0 ) .or. &
+                   ( index(trim(item%levStandardName),"atmosphere_sigma_coordinate") > 0 ) .or. &
+                   ( index(trim(item%levStandardName),"atmosphere_ln_pressure_coordinate") > 0 ) ) then
+                 item%havePressure = .true.
+              endif
            end if
            if (item%havePressure) then
               if (levFile(1)>levFile(size(levFile))) item%fileVDir="up"

--- a/gridcomps/ExtData2G/ExtDataTypeDef.F90
+++ b/gridcomps/ExtData2G/ExtDataTypeDef.F90
@@ -62,6 +62,7 @@ module MAPL_ExtDataTypeDef
      character(len=4)             :: importVDir = "down"
      character(len=4)             :: fileVDir = "down"
      character(len=ESMF_MAXSTR)   :: levUnit
+     character(len=ESMF_MAXSTR)   :: levStandardName
      logical                      :: havePressure = .false.
      type(ExtDataPointerUpdate) :: update_freq
 


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren
Institution: Harvard / GCST

### Describe the update

This PR adds functionality in MAPL to identify input files with dimensionless vertical coordinates that are proxies for pressure and then vertically flip the data based on coordinate values. Previously only files with lev coordinate units equal to 'hpa' or 'pa' were categorized as containing pressure coordinates. Files with vertical coordinates such as hybrid sigma pressure were  not categorized as pressure and the lev positive attribute was used instead to determine whether to flip. This resulted in incorrect flipping because pressure coordinate direction is opposite atmospheric level direction.

To make this fix this update adds unit 'sigma_level' to criteria for determining if lev coordinate is pressure. According to CF-conventions, there are other units possible for dimensionless vertical coordinates, such as 'level'. However, these units are not reliable at distinguishing pressure proxy coordinates from non-pressure coordinates. Therefore this update also adds the capability of extracting 'standard_name' attribute from import files and using it, if present, to further screen the vertical coordinate type.

NOTE: GEOS-Chem Classic outputs diagnostic files using a hybrid sigma pressure coordinate. This update is required to correctly read GEOS-Chem Classic output files into GCHP and GEOS.

### Expected changes

This update correctly applies vertical flipping for cases of CF-convention dimensionless vertical coordinates in the atmosphere that are proxies for pressure.

### References

https://cfconventions.org/Data/cf-conventions/cf-conventions-1.0/build/apd.html

### Related Github Issue(s)

https://github.com/geoschem/GCHP/issues/440




