### PR TITLE
Apply GMAO fix for Intel build error in AbstractComponent.F90

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Fixed compiler bug encountered with certain versions of Intel compilers
 
 ### Added
 - Add debug logger call to print out the name of the container being read from `ExtData.rc`

--- a/generic/AbstractComponent.F90
+++ b/generic/AbstractComponent.F90
@@ -1,4 +1,5 @@
 module mapl_AbstractComponent
+   use pFlogger, only: t_Logger => Logger
    implicit none
    private
 
@@ -96,7 +97,7 @@ module mapl_AbstractComponent
       end subroutine i_RunChild
 
       subroutine i_SetLogger(this, logger)
-         use pFlogger, only: t_Logger => Logger
+         import t_Logger
          import AbstractComponent
          implicit none
          class(AbstractComponent), intent(inout) :: this
@@ -105,7 +106,7 @@ module mapl_AbstractComponent
       end subroutine i_SetLogger
 
       function i_GetLogger(this) result(logger)
-         use pFlogger, only: t_Logger => Logger
+         import t_Logger
          import AbstractComponent
          implicit none
          class(t_Logger), pointer :: logger


### PR DESCRIPTION
### Name and Institution (Required)

Name: Lizzie Lundgren (Harvard). Fix was developed by Matt Thompson and Tom Clune, both at NASA GMAO.

### Describe the update

This PR applies a GMAO fix for intel compatibility going into version 2.26.1 This fix was developed by Matt Thompson and Tom Clune, both at NASA GMAO.

### Expected changes

This is a no diff update.

### Reference(s)

None

### Related Github Issue

https://github.com/GEOS-ESM/MAPL/issues/3295



