### PR TITLE
Enable use of ExtData2G in GCHP Transport Tracers simulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed compiler bug encountered with certain versions of Intel compilers
+- Fixed bug when one of the two names in an ExtData2G rule for a vector is contained in a substring in another item, for example UA;VA and EVAP 
 
 ### Added
 - Add debug logger call to print out the name of the container being read from `ExtData.rc`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ExtData2G criteria for presence of vertical coordinate for cases of non-CF-compliant files
 
 ### Changed
+- Changed default ExtData2G import vertical direction from down to up
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Add debug logger call to print out the name of the container being read from `ExtData.rc`
 - Added dimensionless vertical coordinates to criteria for vertically flipping imports in ExtData
+- Added ExtData2G criteria for presence of vertical coordinate for cases of non-CF-compliant files
 
 ### Changed
 

--- a/gridcomps/ExtData2G/ExtDataConfig.F90
+++ b/gridcomps/ExtData2G/ExtDataConfig.F90
@@ -277,7 +277,7 @@ contains
 
       type(ExtDataRuleMapIterator) :: rule_iterator
       character(len=:), pointer :: key
-      character(len=:), allocatable :: found_key
+      character(len=:), allocatable :: found_key, stripped_name
       logical :: found_rule
 
       _UNUSED_DUMMY(unusable)
@@ -287,7 +287,8 @@ contains
       rule_iterator = this%rule_map%begin()
       do while(rule_iterator /= this%rule_map%end())
          key => rule_iterator%key()
-         if (index(key,trim(item_name))/=0) then
+         stripped_name = strip_multi_rule(key)
+         if (trim(stripped_name)==trim(item_name)) then
             found_rule = .true.
             found_key = key
             exit
@@ -315,7 +316,22 @@ contains
          found_rule = .true.
       end if
       _RETURN(_SUCCESS)
-   end function get_item_type
+
+   contains
+      function strip_multi_rule(full_name) result(stripped_name)
+         character(len=:), allocatable :: stripped_name
+         character(len=*), intent(in) :: full_name
+ 
+         integer :: plus_sign
+         plus_sign = index(full_name,'+')
+         if (plus_sign == 0) then
+            stripped_name=full_name
+         else
+            stripped_name=full_name(:plus_sign-1)
+         end if
+      end function
+
+    end function get_item_type
 
    subroutine add_new_rule(this,key,export_rule,multi_rule,rc)
       class(ExtDataConfig), intent(inout) :: this

--- a/gridcomps/ExtData2G/ExtDataTypeDef.F90
+++ b/gridcomps/ExtData2G/ExtDataTypeDef.F90
@@ -73,7 +73,9 @@ module MAPL_ExtDataTypeDef
 
      type(ESMF_FieldBundle) :: t_interp_bundle
 
-     character(len=4) :: importVDir = "down"
+     ! Change default for GCHP
+     !character(len=4) :: importVDir = "down"
+     character(len=4) :: importVDir = "up"
      logical :: enable_vertical_regrid = .false.
      logical :: allow_vertical_regrid = .false.
      character(len=:), allocatable :: aux_ps, aux_q

--- a/vertical/VerticalCoordinate.F90
+++ b/vertical/VerticalCoordinate.F90
@@ -79,6 +79,7 @@ contains
          if (metadata%has_variable(dim_name)) then
             dim_var => metadata%get_variable(dim_name)
             is_vertical_coord_var = detect_cf_vertical_coord_var(dim_var, _RC)
+            is_vertical_coord_var = is_vertical_coord_var .or. dim_name == 'lev'
             if (is_vertical_coord_var) then
                lev_name = dim_name
                exit 

--- a/vertical/VerticalCoordinate.F90
+++ b/vertical/VerticalCoordinate.F90
@@ -105,24 +105,20 @@ contains
             _RETURN(_SUCCESS)
          end if
 
-         ! now test if no positive attribute and does not have pressure units,
+         ! now test if no positive attribute and does not have pressure units
+         ! for backwards compatibility with non-cf files
          if ((.not. coord_var%is_attribute_present("positive")) .and. &
               (.not. has_pressure_units)) then
             standard_name = coord_var%get_attribute_string("standard_name")
             ! metadata combinations that imply integer levels
-            if ( ((trim(standard_name) == "level" )  .or.  &
-                  (trim(standard_name) == "levels")) .and. &
-                 ((trim(temp_units) == "1"     ) .or. &
-                  (trim(temp_units) == "level")) ) then
-               if (vertical_coord%levels(1) > vertical_coord%levels(2)) then
-                  ! e.g. [72,71,...,2,1]
+            if ( any(standard_name == ["level ", "levels"])  .and. &
+                 any(temp_units == ["1    ", "level"])) then
+               vertical_coord%positive = "up"
+               if (vertical_coord%levels(1) >= vertical_coord%levels(2)) then
                   vertical_coord%positive = "down"
-               else
-                  ! e.g. [1,2,...,71,72]]
-                  vertical_coord%positive = "up"
                endif
             else
-               _ASSERT(.false.,'lev positive attribute not in file and no rule defined for setting it from standard_name and units')
+               _FAIL('lev positive attribute not in file and no rule defined for setting it from standard_name and units')
             endif
          endif
 

--- a/vertical/VerticalCoordinate.F90
+++ b/vertical/VerticalCoordinate.F90
@@ -104,6 +104,28 @@ contains
             if (vertical_coord%levels(1) > vertical_coord%levels(2)) vertical_coord%positive = "up" !bmaa
             _RETURN(_SUCCESS)
          end if
+
+         ! now test if no positive attribute and does not have pressure units,
+         if ((.not. coord_var%is_attribute_present("positive")) .and. &
+              (.not. has_pressure_units)) then
+            standard_name = coord_var%get_attribute_string("standard_name")
+            ! metadata combinations that imply integer levels
+            if ( ((trim(standard_name) == "level" )  .or.  &
+                  (trim(standard_name) == "levels")) .and. &
+                 ((trim(temp_units) == "1"     ) .or. &
+                  (trim(temp_units) == "level")) ) then
+               if (vertical_coord%levels(1) > vertical_coord%levels(2)) then
+                  ! e.g. [72,71,...,2,1]
+                  vertical_coord%positive = "down"
+               else
+                  ! e.g. [1,2,...,71,72]]
+                  vertical_coord%positive = "up"
+               endif
+            else
+               _ASSERT(.false.,'lev positive attribute not in file and no rule defined for setting it from standard_name and units')
+            endif
+         endif
+
          ! now test if this is a "fixed" height level, if has height units, then dimensioanl coordinate, but must have positive 
          has_height_units = safe_are_convertible(temp_units, 'm', _RC)
          if (has_height_units) then


### PR DESCRIPTION
This PR contains two changes to MAPL required for use of ExtData2G in GCHP.

1. A fix from Ben Auer (NASA GMAO) for a bug I reported in reading vector imports with ExtData2G. See https://github.com/GEOS-ESM/MAPL/issues/4158. 
2. Addition of dimension `lev` to the criteria for categorizing import as spatially 3D in ExtData2G.
3. Change default value for ExtData2G primary export data field `importVDir` from `down` to `up`. This means MAPL will vertically flip any spatially 3D imports as needed to be bottom-up prior to exporting to gridded components in GCHP. When using ExtData (1st generation) the gridded components need to track top-down imports, e.g. meteorology from raw GMAO data files, and apply flipping within the gridded component. This is no longer needed if using ExtData2G.
4. Implement vertical flipping of spatially 3D imports in ExtData2G for data files that are not CF-compliant. This includes files that do not contain the positive attribute for the lev dimension while also having non-pressure units. The positive attribute within MAPL is set based on the `standard_name` and `units` of the lev dimension, with the assumption that `level` or `levels` defines value 1 as surface.
